### PR TITLE
rgw: fix multi-RGWDedup Pid collision

### DIFF
--- a/src/rgw/rgw_dedup_manager.cc
+++ b/src/rgw/rgw_dedup_manager.cc
@@ -127,15 +127,16 @@ int RGWDedupManager::get_multi_rgwdedup_info(int& num_rgwdedups, int& cur_id)
     return -1;
   }
 
-  pid_t rgw_pid = getpid();
+  uint64_t rgw_gid = rados->get_instance_id();
   num_rgwdedups = f["services"]["rgw"]["daemons"].object().size();
   int idx = 0;
   for (const auto& [k, v] : f["services"]["rgw"]["daemons"].object()) {
-    if (!v.exists("metadata") || !v["metadata"].exists("pid") ) {
+    if (!v.exists("metadata") || !v["metadata"].exists("pid")) {
       --num_rgwdedups;
       continue;
     }
-    if (rgw_pid == (int)v["metadata"]["pid"]) {
+
+    if (rgw_gid == std::stoi(k)) {
       cur_id = idx;
     }
     ++idx;


### PR DESCRIPTION
It is possible to have the same Pid between RGW containers.

RGWDedups processing same object with the same Pid can lead data inconsistency.

This commit changes identify RGWDedup instance based on gid rather than pid.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
